### PR TITLE
Fix double-sided photo taking for Android

### DIFF
--- a/CameraView.js
+++ b/CameraView.js
@@ -46,9 +46,9 @@ export default function CameraView(props) {
     setTakePhotoCount(takePhotoCount + 1);
     trackEvent("increment", { takePhotoCount });
 
-    await cameraRef.current.takePictureAsync({
-      onPictureSaved: (photo) => onPictureSaved(photo, true),
-    });
+    const photo = await cameraRef.current.takePictureAsync();
+    onPictureSaved(photo, true);
+
     toggleCameraType();
     setTimeout(
       async () => {

--- a/CameraView.js
+++ b/CameraView.js
@@ -137,7 +137,7 @@ const styles = StyleSheet.create({
     justifyContent: "center",
   },
   lensButton: {
-    borderRadius: "50%", /* Make it circular */
+    borderRadius: 40, /* Make it circular */
     borderColor: "white",
     borderWidth: 2,
     width: 80, /* Set the width of the button */

--- a/DisplayPhotoView.js
+++ b/DisplayPhotoView.js
@@ -144,11 +144,9 @@ const styles = StyleSheet.create({
   },
   smallImage: {
     flex: 1,
-    borderWidth: "2px",
-    borderRadius: "25px",
+    borderWidth: 2,
+    borderRadius: 25,
     borderColor: "black",
-    borderWidth: "2px",
-    borderRadius: "25px",
   },
   buttonContainer: {
     flex: 1,


### PR DESCRIPTION
Brings the onlycams revolution to the wonderful world of android. Tested on the iPad.

1. 2cb5ef49f4def9314b41b9b13dc3acda93ed7274 fix some params types that were causing a crash.
2. e2e0993f58e5e317ffe33802fe50abf5c0f50327 modify usage of the first `takePictureAsync` call to ensure the code below it doesn't run until the picture is ready.
3. 9db5a48bdf4bf43e5ff76abadeaf20eaa45e703c use separate `Camera` widgets for each side of the `tookBackPhoto` check, since the `cameraRef.current` reference kept disappearing forever once the first photo was taken. I tried to change as little as possible, but I did switch the `if (!cameraRef) {` to `if (!firstCameraRef.current) {` since I think `current` is the real nullable value.

The share functionality doesn't work yet because `url` is an iOS-only parameter.